### PR TITLE
improve resolving attr "extends" of element "toJava"

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencePathFactory.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencePathFactory.java
@@ -252,7 +252,7 @@ public class XMLReferencePathFactory {
 			String extendsClass = element.getAttribute("extends");
 			if (!StringUtils.isEmpty(extendsClass)) {
 				DefaultExtendedClassProvider implementsClassProvider = new DefaultExtendedClassProvider(
-						extendsClass.split(","));
+						extendsClass.replaceAll("\\s+", "").split(","));
 				return new JavaQuerySpecification(implementsClassProvider);
 			}
 			return null;


### PR DESCRIPTION
Currently, attr extends requires the format <toJava, extends="Foo,Bar"/> strictly, I guess it is better if putting a blank space after a comma is allowed.
