### PR TITLE
fixed-wrong-cursor-position

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/searchers/xml/ContentAssisitCollectorForXML.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/searchers/xml/ContentAssisitCollectorForXML.java
@@ -88,9 +88,7 @@ public class ContentAssisitCollectorForXML extends
 			image = provider.getImage(node);
 			proposedObject = provider.getTextInfo(node);
 		}
-		int cursorPosition = getCursorPosition(value);
-		recorder.recordProposal(image, relevance, displayText, replaceText,
-				cursorPosition, proposedObject);
+		recorder.recordProposal(image, relevance, displayText, replaceText, proposedObject);
 	}
 
 }


### PR DESCRIPTION
after the code completion of text node of type xml-reference-to-xml,
the cursor postion isn't right after the text, but one more offset.
