### PR TITLE
Protect against NPE

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/java/hover/Java2XHover.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/java/hover/Java2XHover.java
@@ -8,7 +8,6 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
-import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.ui.text.java.hover.IJavaEditorTextHover;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
@@ -35,6 +34,10 @@ public class Java2XHover implements IJavaEditorTextHover {
 
 		final IDocument document = textViewer.getDocument();
 		if (document == null) {
+			return null;
+		}
+
+		if (editor == null) {
 			return null;
 		}
 


### PR DESCRIPTION
In my dev environment with the latest eclipse-wtp-search plugins I'm seeing this NPE often:

```
org.eclipse.core.runtime.AssertionFailedException: null argument:
    at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:85)
    at org.eclipse.core.runtime.Assert.isNotNull(Assert.java:73)
    at org.eclipse.jdt.internal.ui.javaeditor.EditorUtility.getEditorInputJavaElement(EditorUtility.java:442)
    at org.eclipse.wst.xml.search.editor.java.hover.Java2XHover.getHoverInfo(Java2XHover.java:41)
    at org.eclipse.jdt.internal.ui.text.java.hover.BestMatchHover.getHoverInfo2(BestMatchHover.java:169)
    at org.eclipse.jdt.internal.ui.text.java.hover.BestMatchHover.getHoverInfo2(BestMatchHover.java:129)
    at org.eclipse.jdt.internal.ui.text.java.hover.JavaEditorTextHoverProxy.getHoverInfo2(JavaEditorTextHoverProxy.java:85)
    at org.eclipse.jface.text.TextViewerHoverManager$4.run(TextViewerHoverManager.java:166)
```

This commit adds a simple null check
