### PR TITLE
Check parent content type to find reference container

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencesManager.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencesManager.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionDelta;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.wst.xml.search.core.namespaces.Namespaces;
 import org.eclipse.wst.xml.search.core.util.StringUtils;
 import org.eclipse.wst.xml.search.editor.internal.Trace;
@@ -133,8 +134,34 @@ public class XMLReferencesManager extends
 		}
 		XMLReferenceContainer container = referencesContainerByContentTypeId
 				.get(contentTypeId);
+
+		if(container == null) {
+			String id = contentTypeId;
+			while(container == null) {
+				IContentType baseType = getParentType(id);
+				if(baseType != null) {
+					id = baseType.getId();
+					container = referencesContainerByContentTypeId.get(id);
+				}
+				else {
+					break;
+				}
+			}
+		}
+
 		return container == null ? null : container.getXMLReferences(node,
 				direction);
+	}
+
+	private IContentType getParentType( String contentTypeId ) {
+		if (contentTypeId != null) {
+			IContentType type =
+				Platform.getContentTypeManager().getContentType(contentTypeId);
+			if (type != null) {
+				return type.getBaseType();
+			}
+		}
+		return null;
 	}
 
 	// XML reference inversed


### PR DESCRIPTION
In liferay projects we override the jspsource content type (alloyjspsource) in order to add liferay specific features to jsp (aui:script, etc) however, all of our xml-search extensions are set to use the jspsource content type and I would like to avoid using the alloyjspsource which is targeted to fixing another problem.  

But for xml-search the xml references manager needs to check the parent types.  So if you have this relationship

```
org.eclipse.core.runtime.text
--> org.eclipse.jst.jsp.core.jspsource
--> --> com.liferay.ide.alloy.core.alloyjspsource
```

then the XmlReferencesManager can check the current contentType but if it fails to match it should go up the contentType to its baseType and so on to see if it finds a match.
