### PR TITLE
Make sure that base content types are always searched

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencesManager.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/internal/references/XMLReferencesManager.java
@@ -132,22 +132,7 @@ public class XMLReferencesManager extends
 			}
 			return references;
 		}
-		XMLReferenceContainer container = referencesContainerByContentTypeId
-				.get(contentTypeId);
-
-		if(container == null) {
-			String id = contentTypeId;
-			while(container == null) {
-				IContentType baseType = getParentType(id);
-				if(baseType != null) {
-					id = baseType.getId();
-					container = referencesContainerByContentTypeId.get(id);
-				}
-				else {
-					break;
-				}
-			}
-		}
+		XMLReferenceContainer container = getXMLReferenceContainer( contentTypeId );
 
 		return container == null ? null : container.getXMLReferences(node,
 				direction);
@@ -380,7 +365,22 @@ public class XMLReferencesManager extends
 
 	public XMLReferenceContainer getXMLReferenceContainer(String contentTypeId) {
 		loadXMLReferencesIfNeeded();
-		return referencesContainerByContentTypeId.get(contentTypeId);
+		XMLReferenceContainer container = referencesContainerByContentTypeId.get(contentTypeId);
+
+		if (container == null) {
+			String id = contentTypeId;
+			while( container == null ) {
+				IContentType baseType = getParentType( id );
+				if( baseType != null ) {
+					id = baseType.getId();
+					container = referencesContainerByContentTypeId.get( id );
+				}
+				else {
+					break;
+				}
+			}
+		}
+		return container;
 	}
 
 	private void loadXMLReferencesIfNeeded() {


### PR DESCRIPTION
We found another place where the JSP reference batch validator wasn't working on our custom jsp content type which is a subtype of the platform jsp content type, so this PR will make sure that all reference container lookups will search through basetypes for matches.
