### PR TITLE
Directly use platform content type API for finding content type

### DIFF
--- a/core/org.eclipse.wst.xml.search.core/src/main/java/org/eclipse/wst/xml/search/core/util/DOMUtils.java
+++ b/core/org.eclipse.wst.xml.search.core/src/main/java/org/eclipse/wst/xml/search/core/util/DOMUtils.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.wst.xml.search.core.util;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,6 +20,9 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentDescription;
+import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.wst.sse.core.StructuredModelManager;
 import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
@@ -484,24 +486,26 @@ public class DOMUtils {
 	 * @return
 	 */
 	public static String getStructuredModelContentTypeId(IFile file) {
-		IStructuredModel model = null;
-		try {
-			model = StructuredModelManager.getModelManager()
-					.getExistingModelForRead(file);
-			if (model == null) {
-				model = StructuredModelManager.getModelManager()
-						.getModelForRead(file);
+		if(file != null) {
+			IContentDescription desc = null;
+			IContentType type = null;
+
+			try {
+				desc = file.getContentDescription();
+
+				if(desc != null) {
+					type = desc.getContentType();
+				}
 			}
-			if (model != null) {
-				return model.getContentTypeIdentifier();
+			catch( CoreException e ) {
 			}
-		} catch (IOException e) {
-			return null;
-		} catch (CoreException e) {
-			return null;
-		} finally {
-			if (model != null) {
-				model.releaseFromRead();
+
+			if(type == null) {
+				type = Platform.getContentTypeManager().findContentTypeFor(file.getName());
+			}
+
+			if(type != null) {
+				return type.getId();
 			}
 		}
 		return null;


### PR DESCRIPTION
fixed #38 

So the previous used model handler API which didn't work for adopters since not all contentTypes have their own model handlers.  So we researched the IStructuredModel loader, how it gets its contentType, and it turns out all of the smarts can be found here:  `org.eclipse.wst.sse.core.internal.FileBufferModelManager.detectContentType(IFileBuffer)` 

If you look in that class you can see if has 8 or 9 different contentType lookup methods and failovers.  However, when the content is an IFile, like it is with XML search's scenario, there are only 2 ways to find contentType for the file, lookup directly and one platform fallback.

So I've replicated that logic here in this new pull and no longer call into the ModelManager to get the content Type.  

This doesn't break Liferay use-cases, but I hope it doesn't break any of your own extensions either, only testing will tell.
