### PR TITLE
support extensions that have empty targetNodes="" attribute

### DIFF
--- a/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/validation/XMLReferencesBatchValidator.java
+++ b/core/org.eclipse.wst.xml.search.editor/src/main/java/org/eclipse/wst/xml/search/editor/validation/XMLReferencesBatchValidator.java
@@ -300,8 +300,8 @@ public class XMLReferencesBatchValidator extends AbstractValidator implements
 				String[] targetNodes = from.getTargetNodes();
 				for (String targetNode : targetNodes) {
 					String xpath = EqualsStringQueryBuilder.INSTANCE.build(
-							path, null, null)
-							+ "/" + targetNode;
+						path, null, null) +
+							( targetNode.isEmpty() ? targetNode : "/" + targetNode);
 					try {
 						NodeList list = XPathManager.getManager()
 								.evaluateNodeSet(null, document, xpath,


### PR DESCRIPTION
In Liferay IDE we need xml search to support reference extensions that don't specify targetNodes="" attribute, because  need to specify a much more complex path extension without the targets being appended.  See [here](https://issues.liferay.com/browse/IDE-1939) for full discussion.
